### PR TITLE
dart 버전의 최소사양을 낮췄습니다.

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,5 +233,5 @@ packages:
     source: hosted
     version: "14.2.5"
 sdks:
-  dart: ">=3.5.4 <4.0.0"
+  dart: ">=3.5.2 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.5.4
+  sdk: ^3.5.2
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
Dart version >= 3.5.4 -> 3.5.2로 변경했습니다.
혹시나 라이브러리 실행에 문제가 있다면 차후에 다시 버전 업해도 됩니다.